### PR TITLE
[feat] 내 일정 생성 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.6",
         "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-popover": "^1.1.6",
+        "@radix-ui/react-scroll-area": "^1.2.3",
         "@radix-ui/react-select": "^2.1.6",
         "@radix-ui/react-separator": "^1.1.2",
         "@radix-ui/react-slot": "^1.1.2",
@@ -1690,6 +1691,36 @@
         "@radix-ui/react-primitive": "2.0.2",
         "@radix-ui/react-use-callback-ref": "1.1.0",
         "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.3.tgz",
+      "integrity": "sha512-l7+NNBfBYYJa9tNqVcP2AGvxdE3lmE6kFTBXdvHgUaZuy+4wGCL1Cl2AfaR7RKyimj7lZURGLwFO59k4eBnDJQ==",
+      "dependencies": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3498,18 +3529,414 @@
       }
     },
     "node_modules/cmdk": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.0.4.tgz",
-      "integrity": "sha512-AnsjfHyHpQ/EFeAnG216WY7A5LiYCoZzCSygiLvfXC3H3LFGCprErteUcszaVluGOhuOTbJS3jWHrSDYPBBygg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.0.0.tgz",
+      "integrity": "sha512-gDzVf0a09TvoJ5jnuPvygTB77+XdOSwEmJ88L6XPFPlv7T3RxbP9jgenfylrAMD0+Le1aO0nVjQUzl2g+vjz5Q==",
       "dependencies": {
-        "@radix-ui/react-dialog": "^1.1.2",
-        "@radix-ui/react-id": "^1.1.0",
-        "@radix-ui/react-primitive": "^2.0.0",
-        "use-sync-external-store": "^1.2.2"
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-primitive": "1.0.3"
       },
       "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
+      "integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-context": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
+      "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-dialog": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.5.tgz",
+      "integrity": "sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz",
+      "integrity": "sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-escape-keydown": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+      "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz",
+      "integrity": "sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz",
+      "integrity": "sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.4.tgz",
+      "integrity": "sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+      "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-id": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz",
+      "integrity": "sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-id/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
+      "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-portal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.4.tgz",
+      "integrity": "sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-presence": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
+      "integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-presence/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
+      "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-primitive": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+      "integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "1.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-slot": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
+      "integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-use-controllable-state/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+      "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cmdk/node_modules/react-remove-scroll": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
+      "integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.3",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/color-convert": {
@@ -6142,6 +6569,8 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
       "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "optional": true,
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.6",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-popover": "^1.1.6",
+    "@radix-ui/react-scroll-area": "^1.2.3",
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.2",

--- a/src/features/calendar/api/dto.ts
+++ b/src/features/calendar/api/dto.ts
@@ -1,7 +1,14 @@
 export type CalendarTypeDTO = 'TEAM' | 'MEMBER' | 'OTHER';
 export type PrivacyTypeDTO = 'PUBLIC' | 'PRIVATE';
 export type AvailabilityTypeDTO = 'FREE' | 'BUSY';
+export interface EventReminderDTO {
+  notifyTime: string; // ISO 8601 형식의 타임스탬프 문자열
+}
 
+/**
+ * 캘린더 정보 DTO
+ * 사용자가 조회 가능한 캘린더 목록 조회 시 반환되는 정보
+ */
 export interface CalendarDTO {
   name: string;
   calendarId: number;
@@ -12,6 +19,10 @@ export interface CalendarDTO {
 
 export type CalendarListDTO = CalendarDTO[];
 
+/**
+ * 일정 조회 결과 DTO
+ * 서버에서 조회된 일정 상세 정보
+ */
 export interface EventDTO {
   eventId: number;
   title: string;
@@ -24,6 +35,10 @@ export interface EventDTO {
   location: string;
 }
 
+/**
+ * 캘린더별 일정 목록 조회 결과 DTO
+ * 특정 캘린더의 일정 목록을 조회할 때 반환되는 정보
+ */
 export interface CalendarEventsDTO {
   calendarId: number;
   calendarType: CalendarTypeDTO;
@@ -31,10 +46,30 @@ export interface CalendarEventsDTO {
   eventDtos: EventDTO[];
 }
 
+/**
+ * 캘린더 일정 조회 매개변수 DTO
+ * 캘린더별 일정 목록 조회 시 사용되는 파라미터
+ */
 export interface CalendarEventsParamsDTO {
   calendarId: number;
   calendarType: CalendarTypeDTO;
   targetUserId?: number;
   targetMonth: number;
   targetYear: number;
+}
+
+/**
+ * 이벤트 생성 및 수정 요청에 사용되는 DTO
+ * 클라이언트에서 서버로 전송되는 일정 데이터 구조
+ */
+export interface EventRequestDTO {
+  title: string;
+  description: string;
+  dtStartTime: string; // ISO 8601 형식의 타임스탬프 문자열 (2025-03-06T01:16:56.032Z)
+  dtEndTime: string; // ISO 8601 형식의 타임스탬프 문자열
+  isAllDay: boolean;
+  privacyType: PrivacyTypeDTO;
+  availability: AvailabilityTypeDTO;
+  location: string;
+  eventReminders: EventReminderDTO[];
 }

--- a/src/features/calendar/api/dto.ts
+++ b/src/features/calendar/api/dto.ts
@@ -1,6 +1,6 @@
 export type CalendarTypeDTO = 'TEAM' | 'MEMBER' | 'OTHER';
 export type PrivacyTypeDTO = 'PUBLIC' | 'PRIVATE';
-export type AvailabilityDTO = 'FREE' | 'BUSY';
+export type AvailabilityTypeDTO = 'FREE' | 'BUSY';
 
 export interface CalendarDTO {
   name: string;
@@ -20,7 +20,7 @@ export interface EventDTO {
   dtEndTime: string; // ISO 8601 형식의 타임스탬프 문자열
   isAllDay: boolean;
   privacyType: PrivacyTypeDTO;
-  availability: AvailabilityDTO;
+  availability: AvailabilityTypeDTO;
   location: string;
 }
 

--- a/src/features/calendar/api/queries.ts
+++ b/src/features/calendar/api/queries.ts
@@ -1,11 +1,13 @@
 import { useMutation, useQueries, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
+import { z } from 'zod';
 
 import {
   CalendarEventsDTO,
   CalendarListDTO,
 } from '@/features/calendar/api/dto';
 import { calendarService } from '@/features/calendar/api/service';
+import { eventSchema } from '@/features/calendar/model/eventSchema';
 
 export const calendarQueries = {
   getCalendars: {
@@ -75,7 +77,21 @@ export const useCalendarEvents = (
 
 export const EventMutations = {
   // 내 캘린더 일정 생성
-  useCreateMyEvent: () => {},
+  useCreateMyEvent: () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+      mutationFn: (formData: z.infer<typeof eventSchema>) =>
+        calendarService.createMyEvent(formData),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['calendarEvents'] });
+        toast.success('일정이 생성되었습니다.');
+      },
+      onError: () => {
+        toast.error('일정 생성에 실패했습니다. 다시 시도해주세요.');
+      },
+    });
+  },
 
   // 팀 캘린더 일정 생성
   useCreateTeamEvent: () => {},

--- a/src/features/calendar/api/service.ts
+++ b/src/features/calendar/api/service.ts
@@ -1,8 +1,12 @@
+import { z } from 'zod';
+
 import {
   CalendarEventsDTO,
   CalendarEventsParamsDTO,
   CalendarListDTO,
 } from '@/features/calendar/api/dto';
+import { eventSchema } from '@/features/calendar/model/eventSchema';
+import { convertFormDataToApiRequest } from '@/features/calendar/model/utils';
 import { apiClient } from '@/shared/api/apiClient';
 import { ApiResponse } from '@/shared/types/apiResponse';
 
@@ -35,6 +39,17 @@ export const calendarService = {
     const response = await apiClient.get<CalendarEventsDTO>({
       url: `calendar/events/${calendarType}`,
       params: params,
+    });
+
+    return response;
+  },
+
+  createMyEvent: async (
+    formData: z.infer<typeof eventSchema>
+  ): Promise<ApiResponse<{}>> => {
+    const response = await apiClient.post<{}>({
+      url: '/calendar/my-events',
+      data: convertFormDataToApiRequest(formData),
     });
 
     return response;

--- a/src/features/calendar/model/eventFormConfig.ts
+++ b/src/features/calendar/model/eventFormConfig.ts
@@ -11,7 +11,7 @@ export type AvailabilityType = AvailabilityTypeDTO;
 export type NotificationType = {
   id: number;
   time: string;
-  unit: 'minutes' | 'hours' | 'days';
+  unit: 'minutes' | 'hours' | 'days' | 'weeks';
 };
 
 export type Participant = {
@@ -34,3 +34,28 @@ export interface EventFormData {
   participants?: Participant[];
   description?: string;
 }
+
+export interface FormFieldConfig {
+  name: keyof EventFormData | string;
+  label?: string;
+  type:
+    | 'text'
+    | 'date'
+    | 'time'
+    | 'checkbox'
+    | 'textarea'
+    | 'select'
+    | 'multiselect'
+    | 'notiselect';
+  placeholder?: string;
+  options?: Array<{ label: string; value: string }>;
+  className?: string;
+  disabled?: boolean | ((data: EventFormData) => boolean);
+  hidden?: boolean | ((data: EventFormData) => boolean);
+}
+
+//**
+// TODO
+// 1. 생성시) 기본 시작일: 오늘, 현재 시간 분단위 반올림 (18:08 -> 18:10)
+// 2. 생성시) 기본 종료일: 시작 시간 1시간 이후
+// 3. allDay === True일 경우 시작 시간 00:00, 종료 시간 23:59으로 설정해 폼 제출 */

--- a/src/features/calendar/model/eventFormConfig.ts
+++ b/src/features/calendar/model/eventFormConfig.ts
@@ -1,0 +1,36 @@
+import {
+  AvailabilityTypeDTO,
+  CalendarTypeDTO,
+  PrivacyTypeDTO,
+} from '@/features/calendar/api/dto';
+
+export type CalendarType = CalendarTypeDTO;
+export type PrivacyType = PrivacyTypeDTO;
+export type AvailabilityType = AvailabilityTypeDTO;
+
+export type NotificationType = {
+  id: number;
+  time: string;
+  unit: 'minutes' | 'hours' | 'days';
+};
+
+export type Participant = {
+  userId: number;
+  name: string;
+};
+
+export interface EventFormData {
+  title: string;
+  startDate: string;
+  startTime: string;
+  endDate: string;
+  endTime: string;
+  allDay: boolean;
+  location?: string;
+  notifications?: NotificationType[];
+  selectedCalendarId: string;
+  visibility: PrivacyType;
+  availability: AvailabilityType;
+  participants?: Participant[];
+  description?: string;
+}

--- a/src/features/calendar/model/eventSchema.ts
+++ b/src/features/calendar/model/eventSchema.ts
@@ -21,7 +21,7 @@ export const eventSchema = z
     allDay: z.boolean().default(true),
     location: z.string().optional(),
     notification: z.array(notificationSchema).optional(),
-    selectedCalendarId: z.number(),
+    selectedCalendarId: z.string(),
     privacyType: z.enum(['PUBLIC', 'PRIVATE'] as const).default('PUBLIC'),
     availability: z.enum(['FREE', 'BUSY'] as const).default('FREE'),
     participants: z.array(participantSchema).optional(), // isTeamEvent일 떄만 나타나는 속성. Option 타입 (label, value)

--- a/src/features/calendar/model/eventSchema.ts
+++ b/src/features/calendar/model/eventSchema.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+
+const notificationSchema = z.object({
+  id: z.number(),
+  time: z.string().min(0, { message: '알림 시간을 입력해주세요.' }),
+  unit: z.enum(['minutes', 'hours', 'days', 'weeks']),
+});
+
+const participantSchema = z.object({
+  userId: z.number(),
+  name: z.string(),
+});
+
+export const eventSchema = z
+  .object({
+    title: z.string().min(1, { message: '제목을 입력해주세요.' }),
+    startDate: z.string().min(1, { message: '시작일을 입력해주세요.' }),
+    startTime: z.string().min(1, { message: '시작 시간을 입력해주세요.' }),
+    endDate: z.string().min(1, { message: '종료일을 입력해주세요.' }),
+    endTime: z.string().min(1, { message: '종료 시간을 입력해주세요.' }),
+    allDay: z.boolean().default(true),
+    location: z.string().optional(),
+    notification: z.array(notificationSchema).optional(),
+    selectedCalendarId: z.number(),
+    privacyType: z.enum(['PUBLIC', 'PRIVATE'] as const).default('PUBLIC'),
+    availability: z.enum(['FREE', 'BUSY'] as const).default('FREE'),
+    participants: z.array(participantSchema).optional(), // isTeamEvent일 떄만 나타나는 속성. Option 타입 (label, value)
+    description: z.string().optional(),
+  })
+  .refine(
+    (data) => {
+      return data.startDate <= data.endDate;
+    },
+    {
+      message: '일정 종료는 시작 시간 이후여야 합니다.',
+      path: ['endDate'],
+    }
+  )
+  .refine(
+    (data) => {
+      if (data.startDate === data.endDate && !data.allDay) {
+        return data.startTime <= data.endTime;
+      }
+
+      return true;
+    },
+    {
+      message: '일정 종료는 시작 시간 이후여야 합니다.',
+      path: ['endTime'],
+    }
+  );
+
+//**
+// TODO
+// 1. 생성시) 기본 시작일: 오늘, 현재 시간 분단위 반올림 (18:08 -> 18:10)
+// 2. 생성시) 기본 종료일: 시작 시간 1시간 이후
+// 3. allDay === True일 경우 시작 시간 00:00, 종료 시간 23:59으로 설정해 폼 제출 */

--- a/src/features/calendar/model/eventSchema.ts
+++ b/src/features/calendar/model/eventSchema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 const notificationSchema = z.object({
   id: z.number(),
-  time: z.number().min(0, { message: '알림 시간을 입력해주세요.' }),
+  time: z.number().min(0).max(1000),
   unit: z.enum(['minutes', 'hours', 'days', 'weeks']),
 });
 
@@ -21,7 +21,7 @@ export const eventSchema = z
     allDay: z.boolean().default(true),
     location: z.string().optional(),
     notification: z.array(notificationSchema).optional(),
-    selectedCalendarId: z.string(),
+    // selectedCalendarId: z.string(),
     privacyType: z.enum(['PUBLIC', 'PRIVATE'] as const).default('PUBLIC'),
     availability: z.enum(['FREE', 'BUSY'] as const).default('FREE'),
     participants: z.array(participantSchema).optional(), // isTeamEvent일 떄만 나타나는 속성. Option 타입 (label, value)
@@ -49,9 +49,3 @@ export const eventSchema = z
       path: ['endTime'],
     }
   );
-
-//**
-// TODO
-// 1. 생성시) 기본 시작일: 오늘, 현재 시간 분단위 반올림 (18:08 -> 18:10)
-// 2. 생성시) 기본 종료일: 시작 시간 1시간 이후
-// 3. allDay === True일 경우 시작 시간 00:00, 종료 시간 23:59으로 설정해 폼 제출 */

--- a/src/features/calendar/model/eventSchema.ts
+++ b/src/features/calendar/model/eventSchema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 const notificationSchema = z.object({
   id: z.number(),
-  time: z.string().min(0, { message: '알림 시간을 입력해주세요.' }),
+  time: z.number().min(0, { message: '알림 시간을 입력해주세요.' }),
   unit: z.enum(['minutes', 'hours', 'days', 'weeks']),
 });
 

--- a/src/features/calendar/model/schema.ts
+++ b/src/features/calendar/model/schema.ts
@@ -1,8 +1,0 @@
-import { z } from 'zod';
-
-export const eventsSchema = z.object({
-  title: z.string().min(1, { message: '일정은 한 글자 이상 입력해주세요.' }),
-  start: z.string(),
-  end: z.date(),
-  description: z.string().min(1, { message: '설명을 입력해 주세요.' }),
-});

--- a/src/features/calendar/model/types.ts
+++ b/src/features/calendar/model/types.ts
@@ -1,7 +1,7 @@
 import { NavigateAction, View } from 'react-big-calendar';
 
 import {
-  AvailabilityDTO,
+  AvailabilityTypeDTO,
   CalendarTypeDTO,
   PrivacyTypeDTO,
 } from '@/features/calendar/api/dto';
@@ -24,6 +24,6 @@ export interface CalendarEventItem {
   end: Date;
   allDay: boolean;
   privacyType: PrivacyTypeDTO;
-  availability: AvailabilityDTO;
+  availability: AvailabilityTypeDTO;
   location: string;
 }

--- a/src/features/calendar/model/utils.ts
+++ b/src/features/calendar/model/utils.ts
@@ -1,5 +1,5 @@
 import {
-  AvailabilityDTO,
+  AvailabilityTypeDTO,
   CalendarEventsDTO,
   PrivacyTypeDTO,
 } from '@/features/calendar/api/dto';
@@ -64,13 +64,13 @@ export const getPrivacyTypeInKorean = (privacyType: PrivacyTypeDTO): string => {
 
 /**
  * 일정 상태(availability)를 한글로 변환하는 함수
- * @param {AvailabilityDTO} availability - 일정 상태 ('FREE' | 'BUSY')
+ * @param {AvailabilityTypeDTO} availability - 일정 상태 ('FREE' | 'BUSY')
  * @returns {string} 한글로 변환된 일정 상태
  */
 export const getAvailabilityInKorean = (
-  availability: AvailabilityDTO
+  availability: AvailabilityTypeDTO
 ): string => {
-  const availabilityMap: Record<AvailabilityDTO, string> = {
+  const availabilityMap: Record<AvailabilityTypeDTO, string> = {
     FREE: '한가함',
     BUSY: '바쁨',
   };

--- a/src/features/calendar/ui/EventForm.tsx
+++ b/src/features/calendar/ui/EventForm.tsx
@@ -1,8 +1,10 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 import { z } from 'zod';
 
 import { CalendarEventItem } from '@/features/calendar/model/types';
+import { ROUTES } from '@/shared/constants/routes';
 import { Button } from '@/shared/ui/shadcn/Button';
 import { Checkbox } from '@/shared/ui/shadcn/Checkbox';
 import {
@@ -23,6 +25,7 @@ import {
 } from '@/shared/ui/shadcn/Select';
 import { Textarea } from '@/shared/ui/shadcn/Textarea';
 
+import { EventMutations } from '../api/queries';
 import { eventSchema } from '../model/eventSchema';
 import { NotificationTimeSelector } from './NotificationTimeSelector';
 
@@ -33,6 +36,9 @@ interface EventFormProps {
 const MAX_NOTIFICATIONS = 5;
 
 export const EventForm = ({ event }: EventFormProps) => {
+  const navigate = useNavigate();
+  const { mutate: createMyEvent } = EventMutations.useCreateMyEvent();
+
   const form = useForm<z.infer<typeof eventSchema>>({
     resolver: zodResolver(eventSchema),
     defaultValues: {
@@ -52,7 +58,13 @@ export const EventForm = ({ event }: EventFormProps) => {
     },
   });
 
-  const onSubmit = (data: z.infer<typeof eventSchema>) => console.log(data);
+  const onSubmit = (data: z.infer<typeof eventSchema>) => {
+    createMyEvent(data, {
+      onSuccess: () => {
+        navigate(ROUTES.CALENDAR.root);
+      },
+    });
+  };
   const onError = (errors: unknown) => console.error('Form errors:', errors);
 
   const allDay = form.watch('allDay');

--- a/src/features/calendar/ui/EventForm.tsx
+++ b/src/features/calendar/ui/EventForm.tsx
@@ -18,29 +18,50 @@ import {
 } from '@/shared/ui/shadcn/Select';
 import { Textarea } from '@/shared/ui/shadcn/Textarea';
 
+import { NotificationTimeSelector } from './NotificationTimeSelector';
+
 interface EventFormProps {
   event: CalendarEventItem;
+}
+
+interface Notification {
+  id: number;
 }
 
 // TODO) 실제 데이터로 대체
 // TODO) type이 MEMBER인 캘린더 - label: name, value: 해당 calendarId
 const PARTICIPANTS: Option[] = [
-  { label: 'nextjs', value: 'nextjs' },
-  { label: 'React', value: 'react' },
-  { label: 'Remix', value: 'remix' },
-  { label: 'Vite', value: 'vite' },
-  { label: 'Nuxt', value: 'nuxt' },
-  { label: 'Vue', value: 'vue' },
-  { label: 'Svelte', value: 'svelte' },
-  { label: 'Angular', value: 'angular' },
-  { label: 'Ember', value: 'ember', disable: true },
-  { label: 'Gatsby', value: 'gatsby', disable: true },
-  { label: 'Astro', value: 'astro' },
+  { label: '혜림/직급1', value: '1' },
+  { label: '태승/직급2', value: '2' },
+  { label: '광호/직급3', value: '3' },
+  { label: '수경/직급4', value: '4' },
 ];
 
 // TODO) 폼 default value를 event 필드 값으로 설정하기
 export const EventForm = ({ event }: EventFormProps) => {
   const [allDay, setAllDay] = useState<boolean>(true);
+
+  const [notifications, setNotifications] = useState<Notification[]>([
+    { id: 1 },
+  ]);
+  const MAX_NOTIFICATIONS = 5;
+
+  const handleAddNotification = () => {
+    console.log('추가 전', notifications.length);
+
+    if (notifications.length < MAX_NOTIFICATIONS) {
+      setNotifications([...notifications, { id: Date.now() }]);
+    }
+
+    console.log('추가 후', notifications.length);
+  };
+
+  const handleRemoveNotification = (idToRemove: number): void => {
+    setNotifications(
+      notifications.filter((notification) => notification.id !== idToRemove)
+    );
+    console.log('삭제 후', notifications.length);
+  };
 
   return (
     <div className='flex h-full w-full gap-x-4 text-sm'>
@@ -60,17 +81,17 @@ export const EventForm = ({ event }: EventFormProps) => {
         {/* allDay === True일 경우 시작 시간 00:00, 종료 시간 23:59으로 설정해 폼 제출 */}
         <div className='flex gap-x-4'>
           <div className='grid w-fit gap-1.5'>
-            <Label>시작일</Label>
+            <Label htmlFor='startDate'>시작일</Label>
             <div className='flex gap-x-2'>
-              <Input type='date' className='w-fit' />
+              <Input type='date' className='w-fit' id='startDate' />
               {!allDay && <Input type='time' className='w-fit' />}
             </div>
           </div>
 
           <div className='grid w-fit gap-1.5'>
-            <Label>종료일</Label>
+            <Label htmlFor='endDate'>종료일</Label>
             <div className='flex gap-x-2'>
-              <Input type='date' className='w-fit' />
+              <Input type='date' className='w-fit' id='endDate' />
               {!allDay && <Input type='time' className='w-fit' />}
             </div>
           </div>
@@ -106,20 +127,33 @@ export const EventForm = ({ event }: EventFormProps) => {
         {/* 알림 */}
         <div className='grid w-[180px] gap-1.5'>
           <Label htmlFor='alert'>알림</Label>
-          {/* 버튼 누르면 여기에 추가 */}
-          {/* TODO) 알림 Select 컴포넌트로 만들기 */}
-          <Button variant='outline' id='alert' type='button'>
-            알림 추가
-          </Button>
+
+          {notifications.map((notification) => (
+            <NotificationTimeSelector
+              key={notification.id}
+              id={notification.id}
+              onRemove={handleRemoveNotification}
+            />
+          ))}
+
+          {notifications.length < MAX_NOTIFICATIONS && (
+            <Button
+              variant='outline'
+              id='alert'
+              type='button'
+              onClick={handleAddNotification}
+            >
+              알림 추가
+            </Button>
+          )}
         </div>
 
         {/* 추가할 캘린더 */}
         <div className='grid w-full gap-1.5'>
           <Label>추가할 캘린더</Label>
 
-          <Select>
+          <Select defaultValue='myCalendar'>
             <SelectTrigger className='w-[180px]'>
-              {/* TODO) 내 캘린더가 기본적으로 선택되도록 설정 */}
               <SelectValue placeholder='추가할 캘린더' />
             </SelectTrigger>
             <SelectContent>
@@ -135,13 +169,12 @@ export const EventForm = ({ event }: EventFormProps) => {
         </div>
 
         {/* 공개 범위 설정 */}
-        <div className='grid w-full gap-1.5'>
+        <div className='grid w-[180px] gap-1.5'>
           <Label>공개 범위</Label>
 
           <div className='flex gap-x-2'>
-            <Select>
-              <SelectTrigger className='w-[180px]'>
-                {/* TODO) '공개'가 기본적으로 선택되도록 설정 */}
+            <Select defaultValue='public'>
+              <SelectTrigger>
                 <SelectValue placeholder='공개 범위' />
               </SelectTrigger>
               <SelectContent>
@@ -152,9 +185,8 @@ export const EventForm = ({ event }: EventFormProps) => {
               </SelectContent>
             </Select>
 
-            <Select>
-              <SelectTrigger className='w-[180px]'>
-                {/* TODO) '바쁨'이 기본적으로 선택되도록 설정 */}
+            <Select defaultValue='busy'>
+              <SelectTrigger>
                 <SelectValue placeholder='표시될 상태' />
               </SelectTrigger>
               <SelectContent>

--- a/src/features/calendar/ui/EventForm.tsx
+++ b/src/features/calendar/ui/EventForm.tsx
@@ -1,14 +1,22 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 import { CalendarEventItem } from '@/features/calendar/model/types';
-import { FindEmptyTime } from '@/features/calendar/ui/FindEmptyTime';
-import { InputWithLabel } from '@/shared/ui/custom/InputWithLabel';
 import MultipleSelector, { Option } from '@/shared/ui/custom/MultipleSelector';
 import { Button } from '@/shared/ui/shadcn/Button';
 import { Checkbox } from '@/shared/ui/shadcn/Checkbox';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/shared/ui/shadcn/Form';
 import { Input } from '@/shared/ui/shadcn/Input';
-import { Label } from '@/shared/ui/shadcn/Label';
 import {
   Select,
   SelectContent,
@@ -20,6 +28,8 @@ import { Textarea } from '@/shared/ui/shadcn/Textarea';
 
 import { CalendarListDTO } from '../api/dto';
 import { calendarQueries } from '../api/queries';
+import { eventSchema } from '../model/eventSchema';
+import { FindEmptyTime } from './FindEmptyTime';
 import { NotificationTimeSelector } from './NotificationTimeSelector';
 
 interface EventFormProps {
@@ -32,7 +42,17 @@ interface Notification {
 
 // TODO) 폼 default value를 event 필드 값으로 설정하기
 export const EventForm = ({ event }: EventFormProps) => {
-  const [allDay, setAllDay] = useState<boolean>(true);
+  const form = useForm<z.infer<typeof eventSchema>>({
+    resolver: zodResolver(eventSchema),
+    // defaultValues: {
+    //   title: event.title,
+    //   startDate: event.start.toDateString(),
+    // },
+  });
+
+  const onSubmit = (data: z.infer<typeof eventSchema>) => console.log(data);
+
+  const allDay = form.watch('allDay');
 
   const [notifications, setNotifications] = useState<Notification[]>([
     { id: 1 },
@@ -55,7 +75,6 @@ export const EventForm = ({ event }: EventFormProps) => {
     ...calendarQueries.getCalendars,
   });
 
-  // calendars에서 isMyCalendar가 true인 값과, calendarType이 TEAM인 값 넣기
   const EVENT_CALENDAR_OPTIONS = useMemo(() => {
     if (!calendars) return [];
 
@@ -66,9 +85,15 @@ export const EventForm = ({ event }: EventFormProps) => {
       .map((calendar) => ({
         id: calendar.calendarId,
         label: calendar.name,
-        value: calendar.isMyCalendar ? 'myCalendar' : 'teamCalendar',
+        value: calendar.calendarId.toString(),
+        isTeamCalendar: calendar.calendarType === 'TEAM',
       }));
   }, [calendars]);
+
+  const selectedCalendarId = form.watch('selectedCalendarId');
+  const isTeamEvent = EVENT_CALENDAR_OPTIONS.some(
+    (cal) => cal.value === selectedCalendarId && cal.isTeamCalendar
+  );
 
   const PARTICIPANTS: Option[] = useMemo(() => {
     if (!calendars) return [];
@@ -77,168 +102,288 @@ export const EventForm = ({ event }: EventFormProps) => {
       .filter((calendar) => calendar.calendarType === 'MEMBER')
       .map((calendar) => ({
         label: calendar.name,
-        value: calendar.calendarId.toString(),
+        value: calendar.typeId.toString(), // userId
       }));
   }, [calendars]);
 
   return (
     <div className='flex h-full w-full gap-x-4 text-sm'>
-      <form className='flex grow flex-col gap-y-6'>
-        {/* 제목, 버튼 */}
-        <div className='flex gap-x-2'>
-          <Input placeholder='제목을 입력하세요.' />
-          <Button type='submit'>저장</Button>
-          <Button type='button' variant='outline'>
-            취소
-          </Button>
-        </div>
-
-        {/* 기간 */}
-        {/* 생성시) 기본 시작일: 오늘, 현재 시각 분 단위 반올림 (18:08 -> 18:10) */}
-        {/* 생성시) 기본 종료일: 오늘, 시작 시간 1시간 이후, 시간에 날짜 맞추기. */}
-        {/* allDay === True일 경우 시작 시간 00:00, 종료 시간 23:59으로 설정해 폼 제출 */}
-        <div className='flex gap-x-4'>
-          <div className='grid w-fit gap-1.5'>
-            <Label htmlFor='startDate'>시작일</Label>
-            <div className='flex gap-x-2'>
-              <Input type='date' className='w-fit' id='startDate' />
-              {!allDay && <Input type='time' className='w-fit' />}
-            </div>
-          </div>
-
-          <div className='grid w-fit gap-1.5'>
-            <Label htmlFor='endDate'>종료일</Label>
-            <div className='flex gap-x-2'>
-              <Input type='date' className='w-fit' id='endDate' />
-              {!allDay && <Input type='time' className='w-fit' />}
-            </div>
-          </div>
-
-          <div className='flex shrink-0 items-center gap-x-1.5'>
-            <Checkbox
-              id='allday'
-              checked={allDay}
-              onCheckedChange={() => setAllDay(!allDay)}
-            />
-            <label
-              htmlFor='allday'
-              className='text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
-            >
-              종일
-            </label>
-          </div>
-        </div>
-
-        {/* 위치 */}
-        <InputWithLabel
-          inputProps={{
-            id: 'location',
-            placeholder: '위치를 작성하세요.',
-            className: 'w-[180px]',
-          }}
-          labelProps={{
-            children: '위치',
-            htmlFor: 'location',
-          }}
-        />
-
-        {/* 알림 */}
-        <div className='grid w-[180px] gap-1.5'>
-          <Label htmlFor='alert'>알림</Label>
-
-          {notifications.map((notification) => (
-            <NotificationTimeSelector
-              key={notification.id}
-              id={notification.id}
-              onRemove={handleRemoveNotification}
-            />
-          ))}
-
-          {notifications.length < MAX_NOTIFICATIONS && (
-            <Button
-              variant='outline'
-              id='alert'
-              type='button'
-              onClick={handleAddNotification}
-            >
-              알림 추가
-            </Button>
-          )}
-        </div>
-
-        {/* 추가할 캘린더 */}
-        <div className='grid w-full gap-1.5'>
-          <Label>추가할 캘린더</Label>
-
-          <Select defaultValue='myCalendar'>
-            <SelectTrigger className='w-[180px]'>
-              <SelectValue placeholder='추가할 캘린더' />
-            </SelectTrigger>
-            <SelectContent>
-              {EVENT_CALENDAR_OPTIONS.map((calendar) => (
-                <SelectItem key={calendar.id} value={calendar.value}>
-                  {calendar.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        {/* 공개 범위 설정 */}
-        <div className='grid w-[180px] gap-1.5'>
-          <Label>공개 범위</Label>
-
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className='flex grow flex-col gap-y-6'
+        >
+          {/* 제목, 버튼 */}
           <div className='flex gap-x-2'>
-            <Select defaultValue='public'>
-              <SelectTrigger>
-                <SelectValue placeholder='공개 범위' />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value='public'>공개</SelectItem>
-                <SelectItem value='private'>비공개</SelectItem>
-              </SelectContent>
-            </Select>
-
-            <Select defaultValue='busy'>
-              <SelectTrigger>
-                <SelectValue placeholder='표시될 상태' />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value='busy'>바쁨</SelectItem>
-                <SelectItem value='free'>한가함</SelectItem>
-              </SelectContent>
-            </Select>
+            <FormField
+              control={form.control}
+              name='title'
+              render={({ field }) => (
+                <FormItem className='grow'>
+                  <FormControl>
+                    <Input placeholder='제목을 입력하세요.' {...field} />
+                  </FormControl>
+                  <FormMessage className='text-xs' />
+                </FormItem>
+              )}
+            />
+            <Button type='submit'>저장</Button>
+            <Button type='button' variant='outline'>
+              취소
+            </Button>
           </div>
-        </div>
 
-        {/* 참석자 */}
-        {event.calendarType === 'TEAM' && (
-          <div className='grid w-full gap-1.5'>
-            <Label>참석자</Label>
+          {/* 기간 */}
+          <div className='flex gap-x-4'>
+            <div className='flex items-end gap-x-2'>
+              <FormField
+                control={form.control}
+                name='startDate'
+                render={({ field }) => (
+                  <FormItem className='w-fit'>
+                    <FormLabel>시작일</FormLabel>
+                    <FormControl>
+                      <Input type='date' {...field} />
+                    </FormControl>
+                    <FormMessage className='text-xs' />
+                  </FormItem>
+                )}
+              />
+              {!allDay && (
+                <FormField
+                  control={form.control}
+                  name='startTime'
+                  render={({ field }) => (
+                    <FormItem className='w-fit'>
+                      <FormControl>
+                        <Input type='time' {...field} />
+                      </FormControl>
+                      <FormMessage className='text-xs' />
+                    </FormItem>
+                  )}
+                />
+              )}
+            </div>
 
-            <MultipleSelector
-              defaultOptions={PARTICIPANTS}
-              placeholder='참석자를 선택하세요.'
-              hidePlaceholderWhenSelected={true}
-              emptyIndicator={
-                <p className='text-center leading-10'>no results found.</p>
-              }
+            <div className='flex items-end gap-x-2'>
+              <FormField
+                control={form.control}
+                name='endDate'
+                render={({ field }) => (
+                  <FormItem className='w-fit'>
+                    <FormLabel>종료일</FormLabel>
+                    <FormControl>
+                      <Input type='date' {...field} />
+                    </FormControl>
+                    <FormMessage className='text-xs' />
+                  </FormItem>
+                )}
+              />
+
+              {!allDay && (
+                <FormField
+                  control={form.control}
+                  name='endTime'
+                  render={({ field }) => (
+                    <FormItem className='w-fit'>
+                      <FormControl>
+                        <Input type='time' {...field} />
+                      </FormControl>
+                      <FormMessage className='text-xs' />
+                    </FormItem>
+                  )}
+                />
+              )}
+            </div>
+
+            <FormField
+              control={form.control}
+              name='allDay'
+              render={({ field }) => (
+                <FormItem className='flex shrink-0 items-center gap-x-1.5'>
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                  <FormLabel className='leading-none'>종일</FormLabel>
+                </FormItem>
+              )}
             />
           </div>
-        )}
 
-        {/* 설명 */}
-        <div className='grid w-full gap-1.5'>
-          <Label htmlFor='description'>설명</Label>
-          <Textarea
-            id='description'
-            placeholder='설명을 추가하세요.'
-            className='h-30 resize-none'
+          {/* 위치 */}
+          <FormField
+            control={form.control}
+            name='location'
+            render={({ field }) => (
+              <FormItem className='w-[180px]'>
+                <FormLabel>위치</FormLabel>
+                <FormControl>
+                  <Input placeholder='위치를 작성하세요.' {...field} />
+                </FormControl>
+              </FormItem>
+            )}
           />
-        </div>
-      </form>
 
-      {event.calendarType === 'TEAM' && <FindEmptyTime />}
+          {/* 알림 */}
+          <FormField
+            control={form.control}
+            name='notification'
+            render={({ field }) => (
+              <FormItem className='w-[180px]'>
+                <FormLabel>알림</FormLabel>
+                {notifications.map((notification) => (
+                  <FormControl>
+                    <NotificationTimeSelector
+                      key={notification.id}
+                      id={notification.id}
+                      onRemove={handleRemoveNotification}
+                    />
+                  </FormControl>
+                ))}
+                {notifications.length < MAX_NOTIFICATIONS && (
+                  <Button
+                    variant='outline'
+                    id='alert'
+                    type='button'
+                    onClick={handleAddNotification}
+                  >
+                    알림 추가
+                  </Button>
+                )}
+              </FormItem>
+            )}
+          />
+
+          {/* 추가할 캘린더 */}
+          <FormField
+            control={form.control}
+            name='selectedCalendarId'
+            render={({ field }) => (
+              <FormItem className='w-[180px]'>
+                <FormLabel>추가할 캘린더</FormLabel>
+                <Select
+                  onValueChange={field.onChange}
+                  defaultValue='myCalendar'
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder='추가할 캘린더' />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {EVENT_CALENDAR_OPTIONS.map((calendar) => (
+                      <SelectItem key={calendar.id} value={calendar.value}>
+                        {calendar.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormItem>
+            )}
+          />
+
+          {/* 공개 범위 설정 */}
+          <div className='flex w-[180px] items-end gap-x-2'>
+            <FormField
+              control={form.control}
+              name='privacyType'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>공개 범위</FormLabel>
+                  <Select
+                    defaultValue='public'
+                    disabled={isTeamEvent}
+                    onValueChange={field.onChange}
+                  >
+                    <FormControl>
+                      <SelectTrigger disabled={isTeamEvent}>
+                        <SelectValue placeholder='공개 범위' />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value='public'>공개</SelectItem>
+                      <SelectItem value='private'>비공개</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name='availability'
+              render={({ field }) => (
+                <FormItem>
+                  <Select
+                    defaultValue='busy'
+                    disabled={isTeamEvent}
+                    onValueChange={field.onChange}
+                  >
+                    <FormControl>
+                      <SelectTrigger disabled={isTeamEvent}>
+                        <SelectValue placeholder='표시될 상태' />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value='busy'>바쁨</SelectItem>
+                      <SelectItem value='free'>한가함</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </FormItem>
+              )}
+            />
+          </div>
+
+          {/* 참석자 */}
+          {isTeamEvent && (
+            <FormField
+              control={form.control}
+              name='participants'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>참석자</FormLabel>
+                  <FormControl>
+                    <MultipleSelector
+                      onChange={field.onChange}
+                      defaultOptions={PARTICIPANTS}
+                      placeholder='참석자를 선택하세요.'
+                      hidePlaceholderWhenSelected={true}
+                      emptyIndicator={
+                        <p className='text-center leading-10'>
+                          no results found.
+                        </p>
+                      }
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          )}
+
+          {/* 설명 */}
+          <FormField
+            control={form.control}
+            name='description'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>설명</FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder='설명을 추가하세요.'
+                    className='h-30 resize-none'
+                    {...field}
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        </form>
+      </Form>
+
+      {isTeamEvent && <FindEmptyTime />}
     </div>
   );
 };

--- a/src/features/calendar/ui/EventForm.tsx
+++ b/src/features/calendar/ui/EventForm.tsx
@@ -1,17 +1,199 @@
-import { CalendarEventItem } from '@/features/calendar/model/types';
+import { useState } from 'react';
 
-import { FindEmptyTime } from './FindEmptyTime';
+import { CalendarEventItem } from '@/features/calendar/model/types';
+import { FindEmptyTime } from '@/features/calendar/ui/FindEmptyTime';
+import { InputWithLabel } from '@/shared/ui/custom/InputWithLabel';
+import MultipleSelector, { Option } from '@/shared/ui/custom/MultipleSelector';
+import { Button } from '@/shared/ui/shadcn/Button';
+import { Checkbox } from '@/shared/ui/shadcn/Checkbox';
+import { Input } from '@/shared/ui/shadcn/Input';
+import { Label } from '@/shared/ui/shadcn/Label';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/ui/shadcn/Select';
+import { Textarea } from '@/shared/ui/shadcn/Textarea';
 
 interface EventFormProps {
   event: CalendarEventItem;
 }
 
+// TODO) 실제 데이터로 대체
+// TODO) type이 MEMBER인 캘린더 - label: name, value: 해당 calendarId
+const PARTICIPANTS: Option[] = [
+  { label: 'nextjs', value: 'nextjs' },
+  { label: 'React', value: 'react' },
+  { label: 'Remix', value: 'remix' },
+  { label: 'Vite', value: 'vite' },
+  { label: 'Nuxt', value: 'nuxt' },
+  { label: 'Vue', value: 'vue' },
+  { label: 'Svelte', value: 'svelte' },
+  { label: 'Angular', value: 'angular' },
+  { label: 'Ember', value: 'ember', disable: true },
+  { label: 'Gatsby', value: 'gatsby', disable: true },
+  { label: 'Astro', value: 'astro' },
+];
+
+// TODO) 폼 default value를 event 필드 값으로 설정하기
 export const EventForm = ({ event }: EventFormProps) => {
-  // TODO) event의 필드 값을 default value로 설정하기
+  const [allDay, setAllDay] = useState<boolean>(true);
 
   return (
-    <div className='flex h-full w-full gap-x-4'>
-      <form className='grow'></form>
+    <div className='flex h-full w-full gap-x-4 text-sm'>
+      <form className='flex grow flex-col gap-y-6'>
+        {/* 제목, 버튼 */}
+        <div className='flex gap-x-2'>
+          <Input placeholder='제목을 입력하세요.' />
+          <Button type='submit'>저장</Button>
+          <Button type='button' variant='outline'>
+            취소
+          </Button>
+        </div>
+
+        {/* 기간 */}
+        {/* 생성시) 기본 시작일: 오늘, 현재 시각 분 단위 반올림 (18:08 -> 18:10) */}
+        {/* 생성시) 기본 종료일: 오늘, 시작 시간 1시간 이후, 시간에 날짜 맞추기. */}
+        {/* allDay === True일 경우 시작 시간 00:00, 종료 시간 23:59으로 설정해 폼 제출 */}
+        <div className='flex gap-x-4'>
+          <div className='grid w-fit gap-1.5'>
+            <Label>시작일</Label>
+            <div className='flex gap-x-2'>
+              <Input type='date' className='w-fit' />
+              {!allDay && <Input type='time' className='w-fit' />}
+            </div>
+          </div>
+
+          <div className='grid w-fit gap-1.5'>
+            <Label>종료일</Label>
+            <div className='flex gap-x-2'>
+              <Input type='date' className='w-fit' />
+              {!allDay && <Input type='time' className='w-fit' />}
+            </div>
+          </div>
+
+          <div className='flex shrink-0 items-center gap-x-1.5'>
+            <Checkbox
+              id='allday'
+              checked={allDay}
+              onCheckedChange={() => setAllDay(!allDay)}
+            />
+            <label
+              htmlFor='allday'
+              className='text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
+            >
+              종일
+            </label>
+          </div>
+        </div>
+
+        {/* 위치 */}
+        <InputWithLabel
+          inputProps={{
+            id: 'location',
+            placeholder: '위치를 작성하세요.',
+            className: 'w-[180px]',
+          }}
+          labelProps={{
+            children: '위치',
+            htmlFor: 'location',
+          }}
+        />
+
+        {/* 알림 */}
+        <div className='grid w-[180px] gap-1.5'>
+          <Label htmlFor='alert'>알림</Label>
+          {/* 버튼 누르면 여기에 추가 */}
+          {/* TODO) 알림 Select 컴포넌트로 만들기 */}
+          <Button variant='outline' id='alert' type='button'>
+            알림 추가
+          </Button>
+        </div>
+
+        {/* 추가할 캘린더 */}
+        <div className='grid w-full gap-1.5'>
+          <Label>추가할 캘린더</Label>
+
+          <Select>
+            <SelectTrigger className='w-[180px]'>
+              {/* TODO) 내 캘린더가 기본적으로 선택되도록 설정 */}
+              <SelectValue placeholder='추가할 캘린더' />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {/** TODO) 실제 calendar name으로 대체
+                 * SelectItem: isMyCalendar가 true인 캘린더, calendar type이 TEAM인 캘린더
+                 */}
+                <SelectItem value='myCalendar'>내 캘린더</SelectItem>
+                <SelectItem value='teamCalendar'>팀 캘린더</SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* 공개 범위 설정 */}
+        <div className='grid w-full gap-1.5'>
+          <Label>공개 범위</Label>
+
+          <div className='flex gap-x-2'>
+            <Select>
+              <SelectTrigger className='w-[180px]'>
+                {/* TODO) '공개'가 기본적으로 선택되도록 설정 */}
+                <SelectValue placeholder='공개 범위' />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectItem value='public'>공개</SelectItem>
+                  <SelectItem value='private'>비공개</SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+
+            <Select>
+              <SelectTrigger className='w-[180px]'>
+                {/* TODO) '바쁨'이 기본적으로 선택되도록 설정 */}
+                <SelectValue placeholder='표시될 상태' />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectItem value='busy'>바쁨</SelectItem>
+                  <SelectItem value='free'>한가함</SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {/* 참석자 */}
+        {event.calendarType === 'TEAM' && (
+          <div className='grid w-full gap-1.5'>
+            <Label>참석자</Label>
+
+            <MultipleSelector
+              defaultOptions={PARTICIPANTS}
+              placeholder='참석자를 선택하세요.'
+              hidePlaceholderWhenSelected={true}
+              emptyIndicator={
+                <p className='text-center leading-10'>no results found.</p>
+              }
+            />
+          </div>
+        )}
+
+        {/* 설명 */}
+        <div className='grid w-full gap-1.5'>
+          <Label htmlFor='description'>설명</Label>
+          <Textarea
+            id='description'
+            placeholder='설명을 추가하세요.'
+            className='h-30 resize-none'
+          />
+        </div>
+      </form>
+
       {event.calendarType === 'TEAM' && <FindEmptyTime />}
     </div>
   );

--- a/src/features/calendar/ui/NotificationTimeSelector.tsx
+++ b/src/features/calendar/ui/NotificationTimeSelector.tsx
@@ -1,0 +1,49 @@
+import { X } from 'lucide-react';
+
+import { Button } from '@/shared/ui/shadcn/Button';
+import { Input } from '@/shared/ui/shadcn/Input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/ui/shadcn/Select';
+
+interface NotificationTimeSelectorProps {
+  id: number;
+  onRemove: (id: number) => void;
+}
+
+export const NotificationTimeSelector = ({
+  id,
+  onRemove,
+}: NotificationTimeSelectorProps) => {
+  return (
+    <div className='flex items-center gap-x-1.5'>
+      <Input type='number' min={0} defaultValue={10} placeholder='시간' />
+
+      <Select defaultValue='minute'>
+        <SelectTrigger>
+          <SelectValue placeholder='단위' />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value='minute'>분</SelectItem>
+          <SelectItem value='hour'>시간</SelectItem>
+          <SelectItem value='day'>일</SelectItem>
+          <SelectItem value='week'>주</SelectItem>
+        </SelectContent>
+      </Select>
+
+      <Button
+        variant='ghost'
+        size='icon'
+        type='button'
+        className='h-fit'
+        onClick={() => onRemove(id)}
+      >
+        <X />
+      </Button>
+    </div>
+  );
+};

--- a/src/features/calendar/ui/NotificationTimeSelector.tsx
+++ b/src/features/calendar/ui/NotificationTimeSelector.tsx
@@ -35,12 +35,12 @@ export const NotificationTimeSelector = ({
     <div className='flex items-center gap-x-1.5'>
       <Input
         type='number'
-        min={0}
-        value={value.time}
-        defaultValue={10}
         placeholder='시간'
+        value={value.time}
+        min={0}
+        max={1000}
         onChange={(e) =>
-          onChange(id, { ...value, time: Number(e.target.value) })
+          onChange(id, { ...value, time: Number(e.target.value) || 0 })
         }
       />
 

--- a/src/features/calendar/ui/NotificationTimeSelector.tsx
+++ b/src/features/calendar/ui/NotificationTimeSelector.tsx
@@ -10,28 +10,62 @@ import {
   SelectValue,
 } from '@/shared/ui/shadcn/Select';
 
+export type NotificationUnit = 'minutes' | 'hours' | 'days' | 'weeks';
+
 interface NotificationTimeSelectorProps {
   id: number;
+  value: {
+    time: number;
+    unit: NotificationUnit;
+  };
+  onChange: (
+    id: number,
+    value: { time: number; unit: NotificationUnit }
+  ) => void;
   onRemove: (id: number) => void;
 }
 
 export const NotificationTimeSelector = ({
   id,
+  value,
+  onChange,
   onRemove,
 }: NotificationTimeSelectorProps) => {
   return (
     <div className='flex items-center gap-x-1.5'>
-      <Input type='number' min={0} defaultValue={10} placeholder='시간' />
+      <Input
+        type='number'
+        min={0}
+        value={value.time}
+        defaultValue={10}
+        placeholder='시간'
+        onChange={(e) =>
+          onChange(id, { ...value, time: Number(e.target.value) })
+        }
+      />
 
-      <Select defaultValue='minute'>
+      <Select
+        defaultValue='minute'
+        value={value.unit}
+        onValueChange={(unit: string) => {
+          if (
+            unit === 'minutes' ||
+            unit === 'hours' ||
+            unit === 'days' ||
+            unit === 'weeks'
+          ) {
+            onChange(id, { ...value, unit });
+          }
+        }}
+      >
         <SelectTrigger>
           <SelectValue placeholder='단위' />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value='minute'>분</SelectItem>
-          <SelectItem value='hour'>시간</SelectItem>
-          <SelectItem value='day'>일</SelectItem>
-          <SelectItem value='week'>주</SelectItem>
+          <SelectItem value='minutes'>분</SelectItem>
+          <SelectItem value='hours'>시간</SelectItem>
+          <SelectItem value='days'>일</SelectItem>
+          <SelectItem value='weeks'>주</SelectItem>
         </SelectContent>
       </Select>
 

--- a/src/shared/ui/custom/MultipleSelector.tsx
+++ b/src/shared/ui/custom/MultipleSelector.tsx
@@ -1,0 +1,633 @@
+import { Command as CommandPrimitive, useCommandState } from 'cmdk';
+import { X } from 'lucide-react';
+import * as React from 'react';
+import { forwardRef, useEffect } from 'react';
+
+import { cn } from '@/shared/lib/utils';
+import { Badge } from '@/shared/ui/shadcn/Badge';
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from '@/shared/ui/shadcn/Command';
+
+export interface Option {
+  value: string;
+  label: string;
+  disable?: boolean;
+  /** fixed option that can't be removed. */
+  fixed?: boolean;
+  /** Group the options by providing key. */
+  [key: string]: string | boolean | undefined;
+}
+interface GroupOption {
+  [key: string]: Option[];
+}
+
+interface MultipleSelectorProps {
+  value?: Option[];
+  defaultOptions?: Option[];
+  /** manually controlled options */
+  options?: Option[];
+  placeholder?: string;
+  /** Loading component. */
+  loadingIndicator?: React.ReactNode;
+  /** Empty component. */
+  emptyIndicator?: React.ReactNode;
+  /** Debounce time for async search. Only work with `onSearch`. */
+  delay?: number;
+  /**
+   * Only work with `onSearch` prop. Trigger search when `onFocus`.
+   * For example, when user click on the input, it will trigger the search to get initial options.
+   **/
+  triggerSearchOnFocus?: boolean;
+  /** async search */
+  onSearch?: (value: string) => Promise<Option[]>;
+  /**
+   * sync search. This search will not showing loadingIndicator.
+   * The rest props are the same as async search.
+   * i.e.: creatable, groupBy, delay.
+   **/
+  onSearchSync?: (value: string) => Option[];
+  onChange?: (options: Option[]) => void;
+  /** Limit the maximum number of selected options. */
+  maxSelected?: number;
+  /** When the number of selected options exceeds the limit, the onMaxSelected will be called. */
+  onMaxSelected?: (maxLimit: number) => void;
+  /** Hide the placeholder when there are options selected. */
+  hidePlaceholderWhenSelected?: boolean;
+  disabled?: boolean;
+  /** Group the options base on provided key. */
+  groupBy?: string;
+  className?: string;
+  badgeClassName?: string;
+  /**
+   * First item selected is a default behavior by cmdk. That is why the default is true.
+   * This is a workaround solution by add a dummy item.
+   *
+   * @reference: https://github.com/pacocoursey/cmdk/issues/171
+   */
+  selectFirstItem?: boolean;
+  /** Allow user to create option when there is no option matched. */
+  creatable?: boolean;
+  /** Props of `Command` */
+  commandProps?: React.ComponentPropsWithoutRef<typeof Command>;
+  /** Props of `CommandInput` */
+  inputProps?: Omit<
+    React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>,
+    'value' | 'placeholder' | 'disabled'
+  >;
+  /** hide the clear all button. */
+  hideClearAllButton?: boolean;
+}
+
+export interface MultipleSelectorRef {
+  selectedValue: Option[];
+  input: HTMLInputElement;
+  focus: () => void;
+  reset: () => void;
+}
+
+export function useDebounce<T>(value: T, delay?: number): T {
+  const [debouncedValue, setDebouncedValue] = React.useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay || 500);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+function transToGroupOption(options: Option[], groupBy?: string) {
+  if (options.length === 0) {
+    return {};
+  }
+  if (!groupBy) {
+    return {
+      '': options,
+    };
+  }
+
+  const groupOption: GroupOption = {};
+  options.forEach((option) => {
+    const key = (option[groupBy] as string) || '';
+    if (!groupOption[key]) {
+      groupOption[key] = [];
+    }
+    groupOption[key].push(option);
+  });
+  return groupOption;
+}
+
+function removePickedOption(groupOption: GroupOption, picked: Option[]) {
+  const cloneOption = JSON.parse(JSON.stringify(groupOption)) as GroupOption;
+
+  for (const [key, value] of Object.entries(cloneOption)) {
+    cloneOption[key] = value.filter(
+      (val) => !picked.find((p) => p.value === val.value)
+    );
+  }
+  return cloneOption;
+}
+
+function isOptionsExist(groupOption: GroupOption, targetOption: Option[]) {
+  for (const [, value] of Object.entries(groupOption)) {
+    if (
+      value.some((option) => targetOption.find((p) => p.value === option.value))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * The `CommandEmpty` of shadcn/ui will cause the cmdk empty not rendering correctly.
+ * So we create one and copy the `Empty` implementation from `cmdk`.
+ *
+ * @reference: https://github.com/hsuanyi-chou/shadcn-ui-expansions/issues/34#issuecomment-1949561607
+ **/
+const CommandEmpty = forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<typeof CommandPrimitive.Empty>
+>(({ className, ...props }, forwardedRef) => {
+  const render = useCommandState((state) => state.filtered.count === 0);
+
+  if (!render) return null;
+
+  return (
+    <div
+      ref={forwardedRef}
+      className={cn('py-6 text-center text-sm', className)}
+      cmdk-empty=''
+      role='presentation'
+      {...props}
+    />
+  );
+});
+
+CommandEmpty.displayName = 'CommandEmpty';
+
+const MultipleSelector = React.forwardRef<
+  MultipleSelectorRef,
+  MultipleSelectorProps
+>(
+  (
+    {
+      value,
+      onChange,
+      placeholder,
+      defaultOptions: arrayDefaultOptions = [],
+      options: arrayOptions,
+      delay,
+      onSearch,
+      onSearchSync,
+      loadingIndicator,
+      emptyIndicator,
+      maxSelected = Number.MAX_SAFE_INTEGER,
+      onMaxSelected,
+      hidePlaceholderWhenSelected,
+      disabled,
+      groupBy,
+      className,
+      badgeClassName,
+      selectFirstItem = true,
+      creatable = false,
+      triggerSearchOnFocus = false,
+      commandProps,
+      inputProps,
+      hideClearAllButton = false,
+    }: MultipleSelectorProps,
+    ref: React.Ref<MultipleSelectorRef>
+  ) => {
+    const inputRef = React.useRef<HTMLInputElement>(null);
+    const [open, setOpen] = React.useState(false);
+    const [onScrollbar, setOnScrollbar] = React.useState(false);
+    const [isLoading, setIsLoading] = React.useState(false);
+    const dropdownRef = React.useRef<HTMLDivElement>(null); // Added this
+
+    const [selected, setSelected] = React.useState<Option[]>(value || []);
+    const [options, setOptions] = React.useState<GroupOption>(
+      transToGroupOption(arrayDefaultOptions, groupBy)
+    );
+    const [inputValue, setInputValue] = React.useState('');
+    const debouncedSearchTerm = useDebounce(inputValue, delay || 500);
+
+    React.useImperativeHandle(
+      ref,
+      () => ({
+        selectedValue: [...selected],
+        input: inputRef.current as HTMLInputElement,
+        focus: () => inputRef?.current?.focus(),
+        reset: () => setSelected([]),
+      }),
+      [selected]
+    );
+
+    const handleClickOutside = (event: MouseEvent | TouchEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node) &&
+        inputRef.current &&
+        !inputRef.current.contains(event.target as Node)
+      ) {
+        setOpen(false);
+        inputRef.current.blur();
+      }
+    };
+
+    const handleUnselect = React.useCallback(
+      (option: Option) => {
+        const newOptions = selected.filter((s) => s.value !== option.value);
+        setSelected(newOptions);
+        onChange?.(newOptions);
+      },
+      [onChange, selected]
+    );
+
+    const handleKeyDown = React.useCallback(
+      (e: React.KeyboardEvent<HTMLDivElement>) => {
+        const input = inputRef.current;
+        if (input) {
+          if (e.key === 'Delete' || e.key === 'Backspace') {
+            if (input.value === '' && selected.length > 0) {
+              const lastSelectOption = selected[selected.length - 1];
+              // If last item is fixed, we should not remove it.
+              if (!lastSelectOption.fixed) {
+                handleUnselect(selected[selected.length - 1]);
+              }
+            }
+          }
+          // This is not a default behavior of the <input /> field
+          if (e.key === 'Escape') {
+            input.blur();
+          }
+        }
+      },
+      [handleUnselect, selected]
+    );
+
+    useEffect(() => {
+      if (open) {
+        document.addEventListener('mousedown', handleClickOutside);
+        document.addEventListener('touchend', handleClickOutside);
+      } else {
+        document.removeEventListener('mousedown', handleClickOutside);
+        document.removeEventListener('touchend', handleClickOutside);
+      }
+
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+        document.removeEventListener('touchend', handleClickOutside);
+      };
+    }, [open]);
+
+    useEffect(() => {
+      if (value) {
+        setSelected(value);
+      }
+    }, [value]);
+
+    useEffect(() => {
+      /** If `onSearch` is provided, do not trigger options updated. */
+      if (!arrayOptions || onSearch) {
+        return;
+      }
+      const newOption = transToGroupOption(arrayOptions || [], groupBy);
+      if (JSON.stringify(newOption) !== JSON.stringify(options)) {
+        setOptions(newOption);
+      }
+    }, [arrayDefaultOptions, arrayOptions, groupBy, onSearch, options]);
+
+    useEffect(() => {
+      /** sync search */
+
+      const doSearchSync = () => {
+        const res = onSearchSync?.(debouncedSearchTerm);
+        setOptions(transToGroupOption(res || [], groupBy));
+      };
+
+      const exec = async () => {
+        if (!onSearchSync || !open) return;
+
+        if (triggerSearchOnFocus) {
+          doSearchSync();
+        }
+
+        if (debouncedSearchTerm) {
+          doSearchSync();
+        }
+      };
+
+      void exec();
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [debouncedSearchTerm, groupBy, open, triggerSearchOnFocus]);
+
+    useEffect(() => {
+      /** async search */
+
+      const doSearch = async () => {
+        setIsLoading(true);
+        const res = await onSearch?.(debouncedSearchTerm);
+        setOptions(transToGroupOption(res || [], groupBy));
+        setIsLoading(false);
+      };
+
+      const exec = async () => {
+        if (!onSearch || !open) return;
+
+        if (triggerSearchOnFocus) {
+          await doSearch();
+        }
+
+        if (debouncedSearchTerm) {
+          await doSearch();
+        }
+      };
+
+      void exec();
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [debouncedSearchTerm, groupBy, open, triggerSearchOnFocus]);
+
+    const CreatableItem = () => {
+      if (!creatable) return undefined;
+      if (
+        isOptionsExist(options, [{ value: inputValue, label: inputValue }]) ||
+        selected.find((s) => s.value === inputValue)
+      ) {
+        return undefined;
+      }
+
+      const Item = (
+        <CommandItem
+          value={inputValue}
+          className='cursor-pointer'
+          onMouseDown={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          onSelect={(value: string) => {
+            if (selected.length >= maxSelected) {
+              onMaxSelected?.(selected.length);
+              return;
+            }
+            setInputValue('');
+            const newOptions = [...selected, { value, label: value }];
+            setSelected(newOptions);
+            onChange?.(newOptions);
+          }}
+        >
+          {`Create "${inputValue}"`}
+        </CommandItem>
+      );
+
+      // For normal creatable
+      if (!onSearch && inputValue.length > 0) {
+        return Item;
+      }
+
+      // For async search creatable. avoid showing creatable item before loading at first.
+      if (onSearch && debouncedSearchTerm.length > 0 && !isLoading) {
+        return Item;
+      }
+
+      return undefined;
+    };
+
+    const EmptyItem = React.useCallback(() => {
+      if (!emptyIndicator) return undefined;
+
+      // For async search that showing emptyIndicator
+      if (onSearch && !creatable && Object.keys(options).length === 0) {
+        return (
+          <CommandItem value='-' disabled>
+            {emptyIndicator}
+          </CommandItem>
+        );
+      }
+
+      return <CommandEmpty>{emptyIndicator}</CommandEmpty>;
+    }, [creatable, emptyIndicator, onSearch, options]);
+
+    const selectables = React.useMemo<GroupOption>(
+      () => removePickedOption(options, selected),
+      [options, selected]
+    );
+
+    /** Avoid Creatable Selector freezing or lagging when paste a long string. */
+    const commandFilter = React.useCallback(() => {
+      if (commandProps?.filter) {
+        return commandProps.filter;
+      }
+
+      if (creatable) {
+        return (value: string, search: string) => {
+          return value.toLowerCase().includes(search.toLowerCase()) ? 1 : -1;
+        };
+      }
+      // Using default filter in `cmdk`. We don't have to provide it.
+      return undefined;
+    }, [creatable, commandProps?.filter]);
+
+    return (
+      <Command
+        ref={dropdownRef}
+        {...commandProps}
+        onKeyDown={(e) => {
+          handleKeyDown(e);
+          commandProps?.onKeyDown?.(e);
+        }}
+        className={cn(
+          'h-auto overflow-visible bg-transparent',
+          commandProps?.className
+        )}
+        shouldFilter={
+          commandProps?.shouldFilter !== undefined
+            ? commandProps.shouldFilter
+            : !onSearch
+        } // When onSearch is provided, we don't want to filter the options. You can still override it.
+        filter={commandFilter()}
+      >
+        <div
+          className={cn(
+            'border-input min-h-10 rounded-md border text-base focus-visible:ring-4 focus-visible:outline-1 aria-invalid:focus-visible:ring-[3px] aria-invalid:focus-visible:outline-none md:text-sm dark:aria-invalid:focus-visible:ring-4',
+            {
+              'px-3 py-2': selected.length !== 0,
+              'cursor-text': !disabled && selected.length !== 0,
+            },
+            className
+          )}
+          onClick={() => {
+            if (disabled) return;
+            inputRef?.current?.focus();
+          }}
+        >
+          <div className='relative flex flex-wrap gap-1'>
+            {selected.map((option) => {
+              return (
+                <Badge
+                  key={option.value}
+                  className={cn(
+                    'data-[disabled]:bg-muted-foreground data-[disabled]:text-muted data-[disabled]:hover:bg-muted-foreground',
+                    'data-[fixed]:bg-muted-foreground data-[fixed]:text-muted data-[fixed]:hover:bg-muted-foreground',
+                    badgeClassName
+                  )}
+                  data-fixed={option.fixed}
+                  data-disabled={disabled || undefined}
+                >
+                  {option.label}
+                  <button
+                    className={cn(
+                      'ring-offset-background focus:ring-ring ml-1 rounded-full outline-none focus:ring-2 focus:ring-offset-2',
+                      (disabled || option.fixed) && 'hidden'
+                    )}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        handleUnselect(option);
+                      }
+                    }}
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                    }}
+                    onClick={() => handleUnselect(option)}
+                  >
+                    <X className='text-muted-foreground hover:text-foreground h-3 w-3' />
+                  </button>
+                </Badge>
+              );
+            })}
+            {/* Avoid having the "Search" Icon */}
+            <CommandPrimitive.Input
+              {...inputProps}
+              ref={inputRef}
+              value={inputValue}
+              disabled={disabled}
+              onValueChange={(value) => {
+                setInputValue(value);
+                inputProps?.onValueChange?.(value);
+              }}
+              onBlur={(event) => {
+                if (!onScrollbar) {
+                  setOpen(false);
+                }
+                inputProps?.onBlur?.(event);
+              }}
+              onFocus={(event) => {
+                setOpen(true);
+                inputProps?.onFocus?.(event);
+              }}
+              placeholder={
+                hidePlaceholderWhenSelected && selected.length !== 0
+                  ? ''
+                  : placeholder
+              }
+              className={cn(
+                'placeholder:text-muted-foreground flex-1 bg-transparent outline-none',
+                {
+                  'w-full': hidePlaceholderWhenSelected,
+                  'px-3 py-2': selected.length === 0,
+                  'ml-1': selected.length !== 0,
+                },
+                inputProps?.className
+              )}
+            />
+            <button
+              type='button'
+              onClick={() => {
+                setSelected(selected.filter((s) => s.fixed));
+                onChange?.(selected.filter((s) => s.fixed));
+              }}
+              className={cn(
+                'absolute right-0 h-6 w-6 p-0',
+                (hideClearAllButton ||
+                  disabled ||
+                  selected.length < 1 ||
+                  selected.filter((s) => s.fixed).length === selected.length) &&
+                  'hidden'
+              )}
+            >
+              <X className='size-4 opacity-50' />
+            </button>
+          </div>
+        </div>
+        <div className='relative'>
+          {open && (
+            <CommandList
+              className='bg-popover text-popover-foreground animate-in absolute top-1 z-10 w-full rounded-md border shadow-md outline-none'
+              onMouseLeave={() => {
+                setOnScrollbar(false);
+              }}
+              onMouseEnter={() => {
+                setOnScrollbar(true);
+              }}
+              onMouseUp={() => {
+                inputRef?.current?.focus();
+              }}
+            >
+              {isLoading ? (
+                <>{loadingIndicator}</>
+              ) : (
+                <>
+                  {EmptyItem()}
+                  {CreatableItem()}
+                  {!selectFirstItem && (
+                    <CommandItem value='-' className='hidden' />
+                  )}
+                  {Object.entries(selectables).map(([key, dropdowns]) => (
+                    <CommandGroup
+                      key={key}
+                      heading={key}
+                      className='h-full overflow-auto'
+                    >
+                      <>
+                        {dropdowns.map((option) => {
+                          return (
+                            <CommandItem
+                              key={option.value}
+                              value={option.label}
+                              disabled={option.disable}
+                              onMouseDown={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                              }}
+                              onSelect={() => {
+                                if (selected.length >= maxSelected) {
+                                  onMaxSelected?.(selected.length);
+                                  return;
+                                }
+                                setInputValue('');
+                                const newOptions = [...selected, option];
+                                setSelected(newOptions);
+                                onChange?.(newOptions);
+                              }}
+                              className={cn(
+                                'cursor-pointer',
+                                option.disable &&
+                                  'text-muted-foreground cursor-default'
+                              )}
+                            >
+                              {option.label}
+                            </CommandItem>
+                          );
+                        })}
+                      </>
+                    </CommandGroup>
+                  ))}
+                </>
+              )}
+            </CommandList>
+          )}
+        </div>
+      </Command>
+    );
+  }
+);
+
+MultipleSelector.displayName = 'MultipleSelector';
+export default MultipleSelector;

--- a/src/shared/ui/shadcn/Badge.tsx
+++ b/src/shared/ui/shadcn/Badge.tsx
@@ -1,0 +1,46 @@
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+
+import { cn } from '@/shared/lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
+  {
+    variants: {
+      variant: {
+        default:
+          'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
+        secondary:
+          'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
+        destructive:
+          'border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/70',
+        outline:
+          'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<'span'> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : 'span';
+
+  return (
+    <Comp
+      data-slot='badge'
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/src/shared/ui/shadcn/Command.tsx
+++ b/src/shared/ui/shadcn/Command.tsx
@@ -1,0 +1,175 @@
+import { Command as CommandPrimitive } from 'cmdk';
+import { SearchIcon } from 'lucide-react';
+import * as React from 'react';
+
+import { cn } from '@/shared/lib/utils';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/ui/shadcn/Dialog';
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot='command'
+      className={cn(
+        'bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandDialog({
+  title = 'Command Palette',
+  description = 'Search for a command to run...',
+  children,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string;
+  description?: string;
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className='sr-only'>
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent className='overflow-hidden p-0'>
+        <Command className='[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5'>
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot='command-input-wrapper'
+      className='flex h-9 items-center gap-2 border-b px-3'
+    >
+      <SearchIcon className='size-4 shrink-0 opacity-50' />
+      <CommandPrimitive.Input
+        data-slot='command-input'
+        className={cn(
+          'placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot='command-list'
+      className={cn(
+        'max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot='command-empty'
+      className='py-6 text-center text-sm'
+      {...props}
+    />
+  );
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot='command-group'
+      className={cn(
+        'text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot='command-separator'
+      className={cn('bg-border -mx-1 h-px', className)}
+      {...props}
+    />
+  );
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot='command-item'
+      className={cn(
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot='command-shortcut'
+      className={cn(
+        'text-muted-foreground ml-auto text-xs tracking-widest',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+};

--- a/src/shared/ui/shadcn/ScrollArea.tsx
+++ b/src/shared/ui/shadcn/ScrollArea.tsx
@@ -1,0 +1,56 @@
+import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
+import * as React from 'react';
+
+import { cn } from '@/shared/lib/utils';
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot='scroll-area'
+      className={cn('relative', className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot='scroll-area-viewport'
+        className='ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] focus-visible:ring-4 focus-visible:outline-1'
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  );
+}
+
+function ScrollBar({
+  className,
+  orientation = 'vertical',
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot='scroll-area-scrollbar'
+      orientation={orientation}
+      className={cn(
+        'flex touch-none p-px transition-colors select-none',
+        orientation === 'vertical' &&
+          'h-full w-2.5 border-l border-l-transparent',
+        orientation === 'horizontal' &&
+          'h-2.5 flex-col border-t border-t-transparent',
+        className
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot='scroll-area-thumb'
+        className='bg-border relative flex-1 rounded-full'
+      />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  );
+}
+
+export { ScrollArea, ScrollBar };


### PR DESCRIPTION
## 📌 연관 이슈

- #12 

## 🚀 작업 내용

### 주요 변경 사항

- **일정 생성 폼 구현**
    - 내 캘린더 일정 생성에 필요한 필드만 유지 (팀 캘린더 일정 생성에 필요한 필드는 제거한 상태)
    - React Hook Form과 Zod를 활용한 폼 상태 관리 및 유효성 검증 구현
        - 폼 기본값 설정 및 에러 핸들링 추가
    - 종일 체크박스 선택 시 시작/종료 시간을 00:00 ~ 23:59로 자동 설정
    - 최대 5개까지 알림 추가 기능 구현 (기본적으로 '10분 전' 알림 설정. 삭제 가능.)
- **폼 데이터 API 요청 형식 변환 유틸 함수 추가**
    - `convertLocalDateToISO`: 로컬 날짜 및 시간을 UTC ISO 문자열로 변환
    - `subtractFromISO`: 특정 시간 단위를 빼서 새로운 ISO 타임스탬프 반환
    - `convertFormDataToApiRequest`: 폼 데이터를 API 요청 형식으로 변환
- **내 일정 생성 API 연동 (`api/service.ts`)**
    - `/api/calendar/my-events` 엔드포인트로 POST 요청을 보내는 `createMyEvent` 함수 추가
    - 폼 데이터를 `convertFormDataToApiRequest`를 활용해 변환 후 전송
- **일정 생성 뮤테이션 훅 추가 (`api/queries.ts`)**
    - `useMutation`을 사용하여 일정 생성 API 호출
    - 성공 시 `'calendarEvents'` 쿼리 무효화하여 데이터 최신화
    - 성공/실패 시 토스트 알림으로 사용자에게 즉각적인 피드백 제공
- **일정 생성 폼 제출 기능 구현 (`ui/EventForm.tsx`)**
    - 폼 제출 시 `createMyEvent` 호출
    - 일정 생성 성공 시 `/calendar` 페이지로 이동

### 스크린샷

일정 생성
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/5e4aac25-493b-4de4-ab8f-6772a9082ecb" />
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/693934db-54b8-4fe6-b34f-0c7dcbb8afca" />
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/b1963f9a-4ca2-4042-a305-f46042abfebf" />
일정 조회 API 응답에 알림 필드가 없어서, 알림을 추가했으나 렌더링되지 않음.

 **다른 계정에서 조회 시**
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/7d7ca8ec-cfbe-44c5-a39c-f7fef3887813" />
수정 필요한 부분

1. 기존에 팀원의 비공개 일정은 다음과 같이 조회할 수 있도록 구현했으나 적용되지 않음.
    - 제목을 '한가함'/'바쁨'으로 변경
    - 알림 필드 및 공개 범위 비표시
2. 일정 생성시 기간을 4/6 9:00 - 4/7 10:00로 설정했는데, 조회 시에는 UTC로 뜸. 로컬 시간으로 조회되도록 수정 필요.

### 테스트

- 로컬 환경에서 일정 생성 기능 정상 동작 확인
- 다양한 입력값에 대한 유효성 검증 테스트 수행
- 일정 생성 후 캘린더 뷰에 정상적으로 표시되는지 확인
- 종일 체크박스 기능 및 알림 추가/제거 기능 정상 동작 확인
- 네트워크 에러 시 토스트 알림 표시 확인

## 📢 참고 사항

- 팀원의 비공개 일정 조회 로직 보완
- `/calendar`의 캘린더 뷰 및 일정 상세 모달에서 한국 기준 날짜로 포맷팅 필요
    - 현재 `src/shared/lib/dayjs.ts`에서 `dayjs.locale('ko');` 설정이 있지만 최상단에서 import되지 않아 적용되지 않는 듯함
- 이 PR에는 팀 캘린더 일정 생성을 위한 커밋도 포함되어 있으나, 우선 삭제한 상태. (추후 별도 PR로 추가 예정)
- `eventFormConfig.ts`의 `FormFieldConfig` 인터페이스는 리팩토링을 위한 코드로, 현재는 사용되지 않음 (이후 활용 예정)