### PR TITLE
[fix] 일정 기간 관련 필드 UTC→KST 시간대 변환하여 표시

### DIFF
--- a/src/features/calendar/model/utils.ts
+++ b/src/features/calendar/model/utils.ts
@@ -1,4 +1,6 @@
 import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
 import { z } from 'zod';
 
 import {
@@ -10,20 +12,23 @@ import {
 import { eventSchema } from '@/features/calendar/model/eventSchema';
 import { CalendarEventItem } from '@/features/calendar/model/types';
 
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
 /**
  * ISO 형식의 날짜 문자열을 Date 객체로 변환하는 함수
  * @param {string} isoString - '2025-02-24T10:00:00'
  * @returns {Date} - new Date(2025, 2, 24, 10, 0)
  */
-const convertISOToDate = (isoString: string): Date => {
-  const date = new Date(isoString);
+const convertISOToKSTDate = (isoString: string): Date => {
+  const kstDate = dayjs.utc(isoString).tz('Asia/Seoul');
 
   return new Date(
-    date.getFullYear(),
-    date.getMonth(),
-    date.getDate(),
-    date.getHours(),
-    date.getMinutes()
+    kstDate.year(),
+    kstDate.month(),
+    kstDate.date(),
+    kstDate.hour(),
+    kstDate.minute()
   );
 };
 
@@ -43,8 +48,8 @@ export const transformEventsForBigCalendar = (
       eventId: event.eventId,
       title: event.title,
       description: event.description,
-      start: convertISOToDate(event.dtStartTime),
-      end: convertISOToDate(event.dtEndTime),
+      start: convertISOToKSTDate(event.dtStartTime),
+      end: convertISOToKSTDate(event.dtEndTime),
       allDay: event.isAllDay,
       privacyType: event.privacyType,
       availability: event.availability,

--- a/src/features/calendar/ui/EventDetailsView.tsx
+++ b/src/features/calendar/ui/EventDetailsView.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
 import {
-  AlarmClock,
   Calendar,
   CalendarClock,
   EyeIcon,
@@ -37,6 +36,26 @@ interface EventDetailsViewProps {
   event: CalendarEventItem;
   isRestrictedEvent: boolean;
 }
+
+const getEventTimeDisplay = (event: CalendarEventItem) => {
+  const { start, end, allDay } = event;
+
+  const isSameDay = isSameDate(start, end);
+
+  if (isSameDay) {
+    if (allDay) {
+      return formatDate(event.start);
+    } else {
+      return `${formatDate(event.start)} ${formatTime(event.start)} - ${formatTime(event.end)}`;
+    }
+  } else {
+    if (allDay) {
+      return `${formatDate(event.start)} - ${formatDate(event.end)}`;
+    } else {
+      return `${formatDateTime(event.start)} - ${formatDateTime(event.end)}`;
+    }
+  }
+};
 
 export const EventDetailsView = ({
   event,
@@ -109,17 +128,7 @@ export const EventDetailsView = ({
       {/* 기간 */}
       <div className='flex items-center gap-2'>
         <CalendarClock size='1rem' className='shrink-0' />
-        {isSameDate(event.start, event.end) ? (
-          event.allDay ? (
-            <p>{formatDate(event.start)}</p>
-          ) : (
-            <p>{`${formatDate(event.start)} ${formatTime(event.start)} - ${formatTime(event.end)}`}</p>
-          )
-        ) : event.allDay ? (
-          <p>{`${formatDate(event.start)} - ${formatDate(event.end)}`}</p>
-        ) : (
-          <p>{`${formatDateTime(event.start)} - ${formatDateTime(event.end)}`}</p>
-        )}
+        <p>{getEventTimeDisplay(event)}</p>
       </div>
 
       {!isRestrictedEvent && (
@@ -149,14 +158,6 @@ export const EventDetailsView = ({
               <p>{event.description}</p>
             </div>
           )}
-
-          {/* 알림 */}
-          {/* TODO) 알림 유무도 조건으로 추가 */}
-          <div className='flex items-center gap-2'>
-            <AlarmClock size='1rem' className='shrink-0' />
-            {/* TODO) 백엔드에서 event에 eventReminders 필드 추가하면 반영 */}
-            <p className='text-muted-foreground'>추가된 알림이 없습니다.</p>
-          </div>
 
           {/* 공개 범위 */}
           {event.isMyCalendar && (

--- a/src/pages/calendar/index.tsx
+++ b/src/pages/calendar/index.tsx
@@ -2,6 +2,7 @@ import 'react-big-calendar/lib/css/react-big-calendar.css';
 
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
 import { useMemo, useState } from 'react';
 import { Calendar, dayjsLocalizer } from 'react-big-calendar';
 
@@ -17,6 +18,8 @@ import { useCalendarStore } from '@/features/calendar/model/useCalendarStore';
 import { transformEventsForBigCalendar } from '@/features/calendar/model/utils';
 import { CustomEvent } from '@/features/calendar/ui/CustomEvent';
 import { CustomToolbar } from '@/features/calendar/ui/CustomToolbar';
+
+dayjs.extend(utc);
 
 const localizer = dayjsLocalizer(dayjs);
 


### PR DESCRIPTION
## 📌 연관 이슈

- #16 

## 🚀 작업 내용

### 배경

- 캘린더와 상세 조회 모달에서 일정 조회 시 UTC 시간대로 표시되는 문제가 발생했습니다.
- 사용자가 일정 생성 시 로컬 시간(KST)으로 4/6 9:00 - 4/7 10:00로 설정한 일정이 실제 조회 시에는 UTC 시간대로 표시되어 시간이 맞지 않는 문제가 있었습니다.
- API에서 반환되는 날짜/시간 데이터(dtStartTime, dtEndTime)가 UTC 기준으로 제공되어 적절한 변환이 필요했습니다.

### 주요 변경 사항

1. 시간대 변환을 위해 dayjs의 `utc`와 `timezone` 플러그인 추가
2. UTC → KST 변환 함수 개선
    - API에서 반환되는 날짜/시간 데이터(dtStartTime, dtEndTime)에 'Z'가 포함되지 않아 UTC로 인식하지 못하는 문제 해결
    - 기존의 convertISOToDate 함수를 convertISOToKSTDate로 개선하여 UTC 기준 날짜 문자열을 KST로 올바르게 변환하도록 수정
    ```tsx
    const convertISOToKSTDate = (isoString: string): Date => {
      const kstDate = dayjs.utc(isoString).tz('Asia/Seoul');
    
      return new Date(
        kstDate.year(),
        kstDate.month(),
        kstDate.date(),
        kstDate.hour(),
        kstDate.minute()
      );
    };
    
    ```
3. 캘린더 페이지에 dayjs의 utc 플러그인 추가

### 테스트

- [x] 로깅을 통해 API 응답이 KST로 올바르게 변환되는 것 확인
- [x] 로컬 환경에서 캘린더 일정이 정확한 한국 시간으로 표시되는 것 확인
- [x] 일정 생성 시 설정한 시간(4/6 9:00 - 4/7 10:00)이 캘린더에 동일하게 표시되는지 확인
- [x] 일정 상세 모달에서도 동일한 시간이 표시되는지 확인
- [x] 여러 날짜에 걸친 일정이 정확하게 표시되는지 확인

## 📢 참고사항

- 시간대 변환 로직은 현재 `model/utils.ts` 내에 구현되어 있지만, `calendar/lib/dayjs/` 내로 옮길 계획입니다. (dayjs 확장 로직들도 캘린더 페이지에서 이 폴더 내로 이동할 예정)
- **⚠️ 현재 allDay 일정 처리에 문제가 있습니다.**
  - 종일 버튼을 체크하지 않고 4/8 12:00 시작, 4/8 23:59 종료로 일정을 생성할 경우 정상적으로 뜹니다.  <img width="1552" alt="image" src="https://github.com/user-attachments/assets/67c76c03-a7aa-4170-a42b-3ef5fec84dc6" />
  - 그러나 종일 버튼을 체크하고 4/8 12:00 시작, 4/8 23:59 종료로 일정을 생성할 경우 실제로는 4/7-4/9로 표시되는 문제가 발생합니다.  <img width="1552" alt="image" src="https://github.com/user-attachments/assets/2e9917c7-57b0-450e-a1b9-b4bc4505952f" />